### PR TITLE
Upgrade dependencies and Heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 PyJWT==1.*
-aiohttp==1.0.*
-cryptography==1.*
-fakeredis==0.8.*
-redis==2.10.*
-
-# We need a recent commit of Bottle master for its aiohttp/asyncio support
-# Switch to bottle==0.13.* when released
-https://github.com/bottlepy/bottle/archive/7c1c1ca314f3eff8cc2deb894be5d02f7940fe3c.zip
+bottle==0.12.*
+cryptography==2.6.*
+fakeredis==1.*
+redis==3.2.*
+waitress==1.*

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.7.3

--- a/server.py
+++ b/server.py
@@ -307,4 +307,4 @@ if __name__ == '__main__':
     print()
 
     app.run(host=SETTINGS['ListenIP'], port=SETTINGS['ListenPort'],
-            server='aiohttp')
+            server='waitress')

--- a/settings.py
+++ b/settings.py
@@ -32,7 +32,7 @@ def load():
     See ``README.rst`` and ``config.ini.dist`` for more information.
     """
     parser = ConfigParser(default_section=INI_SECTION,
-                          defaults={key: val for _, key, val in META})
+                          defaults={key: val for _, key, val in META if val})
 
     settings = parser[INI_SECTION]
 


### PR DESCRIPTION
Heroku wanted us to upgrade from the old stack, so I looked into upgrading deps.

I don't think the threading with fakeredis is an issue anymore with newer releases. Seems to work fine anyways. I think this was the only reason we were using aiohttp and a dev build of bottle. This takes us back to stable bottle, and switches to aiohttp to waitress.

This branch is already running on Heroku.