### PR TITLE
Systemd support.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -9,8 +9,8 @@ META = (
     ('DEMO_LISTEN_PORT', 'ListenPort', '8000'),
     ('DEMO_WEBSITE_URL', 'WebsiteURL', 'http://localhost:8000'),
     ('DEMO_BROKER_URL',  'BrokerURL',  'https://broker.portier.io'),
-    ('DEMO_REDIS_URL',   'RedisURL',   None),
-    ('DEMO_SECRET',      'Secret',     None),
+    ('DEMO_REDIS_URL',   'RedisURL',   ''),
+    ('DEMO_SECRET',      'Secret',     ''),
 )
 
 HEROKU_REDIS_ENV_VARS = ('REDISTOGO_URL', 'REDISGREEN_URL', 'REDISCLOUD_URL',
@@ -32,7 +32,7 @@ def load():
     See ``README.rst`` and ``config.ini.dist`` for more information.
     """
     parser = ConfigParser(default_section=INI_SECTION,
-                          defaults={key: val for _, key, val in META if val})
+                          defaults={key: val for _, key, val in META})
 
     settings = parser[INI_SECTION]
 
@@ -59,7 +59,7 @@ def load():
             settings[key] = ENV[var]
 
     # Generate a random Secret if none was set
-    if settings['Secret'] is None:
+    if not settings['Secret']:
         settings['Secret'] = bytearray(urandom(32)).hex()
 
     return settings

--- a/settings.py
+++ b/settings.py
@@ -58,8 +58,23 @@ def load():
         if var in ENV:
             settings[key] = ENV[var]
 
+    # Try to read a secret from the state directory.
+    secret_file = None
+    if not settings['Secret'] and 'STATE_DIRECTORY' in ENV:
+        secret_file = '%s/secret.txt' % ENV['STATE_DIRECTORY']
+        try:
+            with open(secret_file, 'r') as f:
+                settings['Secret'] = f.read()
+        except OSError:
+            pass
+
     # Generate a random Secret if none was set
     if not settings['Secret']:
         settings['Secret'] = bytearray(urandom(32)).hex()
+
+        # Write the secret to the state directory.
+        if secret_file:
+            with open(secret_file, 'w') as f:
+                f.write(settings['Secret'])
 
     return settings


### PR DESCRIPTION
The first commit allows leaving `DEMO_SECRET` unset when the environment is the sole source of configuration. (I don't think we should care for `None` vs `''`.)

The second commit stores the generated secret in `STATE_DIRECTORY` if set in the environment. This is a systemd convention.